### PR TITLE
add spawn which uses luv with vim.loop for neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Lightweight observables and iterables for Lua based on [Callbag Spec](https://gi
 | No            | throttle                                               |
 | No            | timeout                                                |
 
+## Vim Job and Channels
+
+| Implemented   | Name                                                   |
+|---------------|--------------------------------------------------------|
+| Neovim only   | spawn                                                  |
+
+`spawn` uses `vim.loop` in Neovim.
+
 ## Utils
 
 | Implemented   | Name                                                   |

--- a/callbag.lua
+++ b/callbag.lua
@@ -579,9 +579,9 @@ function M.spawn(cmd, opt)
     if not opt then opt = {} end
 	local command = cmd[1]
 	if not (vim.fn.executable(command) == 1) then
-		err('Command ' .. command .. ' not found.')
-		return
-	end
+        err('Command ' .. command .. ' not found.')
+        return
+    end
     return M.create(function (next, err, complete)
         if vim and vim.api ~= nil then
             local uv = vim.loop
@@ -637,13 +637,13 @@ function M.spawn(cmd, opt)
                 if opt['exit'] then
                     next({ event = 'exit', data = { exitcode = exitcode }, state = opt['state'] })
                 end
-				local failOnNonZeroExitCode = opt['failOnNonZeroExitCode']
-				if failOnNonZeroExitCode == nil then failOnNonZeroExitCode = true end
-				if failOnNonZeroExitCode and exitcode ~= 0 then
-					err('Spawn for job failed with exit code ' .. exitcode .. '.')
-				else
-					complete()
-				end
+                local failOnNonZeroExitCode = opt['failOnNonZeroExitCode']
+                if failOnNonZeroExitCode == nil then failOnNonZeroExitCode = true end
+                if failOnNonZeroExitCode and exitcode ~= 0 then
+                    err('Spawn for job failed with exit code ' .. exitcode .. '.')
+                else
+                    complete()
+                end
             end
 
             handle, pid = uv.spawn(command, {
@@ -679,3 +679,5 @@ function M.spawn(cmd, opt)
 end
 
 return M
+
+" vim:ts=4:sw=4:ai:foldmethod=marker:foldlevel=0:

--- a/callbag.lua
+++ b/callbag.lua
@@ -585,7 +585,7 @@ function M.spawn(cmd, opt)
     return M.create(function (next, err, complete)
         if vim and vim.api ~= nil then
             local uv = vim.loop
-			local spawn_options = {}
+            local spawn_options = {}
             local handle
             local pid
             local stdin = uv.new_pipe(false)

--- a/callbag.lua
+++ b/callbag.lua
@@ -579,12 +579,13 @@ function M.spawn(cmd, opt)
     if not opt then opt = {} end
 	local command = cmd[1]
 	if not (vim.fn.executable(command) == 1) then
-        err('Command ' .. command .. ' not found.')
-        return
-    end
+		err('Command ' .. command .. ' not found.')
+		return
+	end
     return M.create(function (next, err, complete)
         if vim and vim.api ~= nil then
             local uv = vim.loop
+			local spawn_options = {}
             local handle
             local pid
             local stdout
@@ -637,19 +638,19 @@ function M.spawn(cmd, opt)
                 if opt['exit'] then
                     next({ event = 'exit', data = { exitcode = exitcode }, state = opt['state'] })
                 end
-                local failOnNonZeroExitCode = opt['failOnNonZeroExitCode']
-                if failOnNonZeroExitCode == nil then failOnNonZeroExitCode = true end
-                if failOnNonZeroExitCode and exitcode ~= 0 then
-                    err('Spawn for job failed with exit code ' .. exitcode .. '.')
-                else
-                    complete()
-                end
+				local failOnNonZeroExitCode = opt['failOnNonZeroExitCode']
+				if failOnNonZeroExitCode == nil then failOnNonZeroExitCode = true end
+				if failOnNonZeroExitCode and exitcode ~= 0 then
+					err('Spawn for job failed with exit code ' .. exitcode .. '.')
+				else
+					complete()
+				end
             end
 
-            handle, pid = uv.spawn(command, {
-                args = {unpack(cmd, 2, #cmd)},
-                stdio = stdio
-            }, on_exit)
+			spawn_options['args'] = {unpack(cmd, 2, #cmd)}
+			spawn_options['stdio'] =stdio
+
+            handle, pid = uv.spawn(command, spawn_options, on_exit)
 
             if opt['start'] then
                 next({ event = 'start', data = { state = opt['state'] } })
@@ -679,5 +680,3 @@ function M.spawn(cmd, opt)
 end
 
 return M
-
-" vim:ts=4:sw=4:ai:foldmethod=marker:foldlevel=0:

--- a/callbag.lua
+++ b/callbag.lua
@@ -578,10 +578,10 @@ end
 function M.spawn(cmd, opt)
     if not opt then opt = {} end
 	local command = cmd[1]
-	if not (vim.fn.executable(command) == 1) then
-		err('Command ' .. command .. ' not found.')
-		return
-	end
+    if not (vim.fn.executable(command) == 1) then
+        err('Command ' .. command .. ' not found.')
+        return
+    end
     return M.create(function (next, err, complete)
         if vim and vim.api ~= nil then
             local uv = vim.loop
@@ -628,17 +628,17 @@ function M.spawn(cmd, opt)
                 if opt['exit'] then
                     next({ event = 'exit', data = { exitcode = exitcode }, state = opt['state'] })
                 end
-				local failOnNonZeroExitCode = opt['failOnNonZeroExitCode']
-				if failOnNonZeroExitCode == nil then failOnNonZeroExitCode = true end
-				if failOnNonZeroExitCode and exitcode ~= 0 then
-					err('Spawn for job failed with exit code ' .. exitcode .. '.')
-				else
-					complete()
-				end
+                local failOnNonZeroExitCode = opt['failOnNonZeroExitCode']
+                if failOnNonZeroExitCode == nil then failOnNonZeroExitCode = true end
+                if failOnNonZeroExitCode and exitcode ~= 0 then
+                    err('Spawn for job failed with exit code ' .. exitcode .. '.')
+                else
+                    complete()
+                end
             end
 
-			spawn_options['args'] = {unpack(cmd, 2, #cmd)}
-			spawn_options['stdio'] = { stdin, stdout, stderr }
+            spawn_options['args'] = {unpack(cmd, 2, #cmd)}
+            spawn_options['stdio'] = { stdin, stdout, stderr }
 
             handle, pid = uv.spawn(command, spawn_options, on_exit)
 

--- a/callbag.lua
+++ b/callbag.lua
@@ -659,7 +659,7 @@ function M.spawn(cmd, opt)
             if opt['stderr'] then uv.read_start(stderr, on_stderr) end
 
             return function ()
-				close_safely(handle)
+                close_safely(handle)
             end
 
             -- uv.write(stdin, "Hello world")

--- a/callbag.lua
+++ b/callbag.lua
@@ -715,7 +715,7 @@ end
 -- stdin(2) -- required to close stdin
 function M.spawn(cmd, opt)
     if not opt then opt = {} end
-	local command = cmd[1]
+    local command = cmd[1]
     if not (vim.fn.executable(command) == 1) then
         err('Command ' .. command .. ' not found.')
         return

--- a/callbag.lua
+++ b/callbag.lua
@@ -697,7 +697,7 @@ end
 -- C.pipe(
 --  C.spawn({'bash', '-c', 'read i; echo $i'}, {
 --   stdin = stdin,
---   stdount = 0,
+--   stdout = 0,
 --   stderr = 0,
 --   exit = 0,
 --   start = 0 -- when job starts before subscribing to stdin

--- a/callbag.lua
+++ b/callbag.lua
@@ -2,6 +2,7 @@ local t_string = 'string'
 local t_function = 'function'
 local t_table = 'table'
 
+local uv
 local noop = function () end
 local unpack = table.unpack or unpack
 
@@ -40,6 +41,7 @@ local initvim = function ()
     if vim.api ~= nil then
         vimcmd = vim.api.nvim_command
         vimeval = vim.api.nvim_eval
+        uv = vim.loop
     else
         vimcmd = vim.command
         vimeval = vim.eval
@@ -584,7 +586,6 @@ function M.spawn(cmd, opt)
     end
     return M.create(function (next, err, complete)
         if vim and vim.api ~= nil then
-            local uv = vim.loop
             local spawn_options = {}
             local handle
             local pid

--- a/callbag.lua
+++ b/callbag.lua
@@ -603,7 +603,8 @@ function M.spawn(cmd, opt)
                     -- TODO: handle error
                     return
                 end
-                if opt['stdout'] then
+                -- nil data means end of stdout
+                if opt['stdout'] and data then
                     next({ event = 'stdout', data = data, state = opt['state'] })
                 end
             end
@@ -613,7 +614,8 @@ function M.spawn(cmd, opt)
                     -- TODO: handle error
                     return
                 end
-                if opt['stderr'] then
+                -- nil data means end of stderr
+                if opt['stderr'] and data then
                     next({ event = 'stderr', data = data, state = opt['state'] })
                 end
             end


### PR DESCRIPTION
Follows the same contract as [callbag.vim](https://github.com/prabirshrestha/callbag.vim) `spawn`.

Currently only works for neovim. Unlike callbag.vim which uses neovim's jobstart this uses luv `vim.loop`